### PR TITLE
Fix: Hierarchy error during export

### DIFF
--- a/mafia_4ds/mafia_4ds_export.py
+++ b/mafia_4ds/mafia_4ds_export.py
@@ -260,9 +260,15 @@ class Mafia4ds_Exporter:
         
         parentIdx = 0
         parent    = mesh.parent
-        
+
         if parent:
-            parentIdx = meshes.index(parent) + 1
+            idxCounter = 1
+            for im in meshes:
+                if im == parent:
+                    parentIdx = idxCounter
+                    break
+                elif not self.IsLod(im):
+                    idxCounter += 1
         
         location = mesh.location
         scale    = mesh.scale


### PR DESCRIPTION
There's a bug in the exporter caused by the fact that exporter counts LODs of a single mesh as separate objects.  When there's a mesh with multiple LODs this shifts index of following objects and their child objects are exported with corrupted parent relation (see #6). This change makes sure LODs are counted correctly and fixes the bug.